### PR TITLE
Switch to mariadb-java-client to remove GPL

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,5 +1,5 @@
 {  
-  "scanSettings": { 
+  "scanSettings": {    
     "configMode": "LOCAL",
     "configExternalURL": "",
     "projectToken": "",

--- a/.whitesource
+++ b/.whitesource
@@ -1,5 +1,5 @@
 {  
-  "scanSettings": {
+  "scanSettings": { 
     "configMode": "LOCAL",
     "configExternalURL": "",
     "projectToken": "",

--- a/.whitesource
+++ b/.whitesource
@@ -1,4 +1,4 @@
-{
+{  
   "scanSettings": {
     "configMode": "LOCAL",
     "configExternalURL": "",

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
-		<dependency>
+		<dependency>   
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<version>5.1.24</version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,10 +101,17 @@
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+<!--
 		<dependency>   
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<version>5.1.24</version>
+		</dependency>
+-->
+		<dependency>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<version>2.7.2</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.owasp.encoder/encoder -->


### PR DESCRIPTION
Change pom.xml to use mariadb-java-client instead of mysql-connector, as mysql-connector uses GPL.